### PR TITLE
Performance upgrade

### DIFF
--- a/examples/usage/main.go
+++ b/examples/usage/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/senpathi/gofloat"
 	"math"
+
+	"github.com/senpathi/gofloat"
 )
 
 func main() {

--- a/gofloat.go
+++ b/gofloat.go
@@ -7,71 +7,83 @@ import (
 
 // Float is to keep float's integer value, decimal value and its precision
 type Float struct {
-	integer   int64
-	decimal   int64
-	precision int
+	integer         int64
+	decimal         int64
+	precision       int
+	precisionFactor int64
 }
 
 // ToFloat returns a Float of f to given precision
 func ToFloat(f float64, precision int) Float {
-	floatingLength := int64(math.Trunc(math.Pow(10, float64(precision))))
-	rounded := math.Round(f * float64(floatingLength))
+	precision = int(math.Abs(float64(precision)))
+	floatingLength := math.Pow10(precision)
 
+	return toFloat(f, precision, int64(floatingLength))
+}
+
+func toFloat(f float64, precision int, precisionFactor int64) Float {
+	rounded := math.Round(f * float64(precisionFactor))
 	return Float{
-		integer:   int64(rounded) / floatingLength,
-		decimal:   int64(rounded) % floatingLength,
-		precision: precision,
+		integer:         int64(rounded) / precisionFactor,
+		decimal:         int64(rounded) % precisionFactor,
+		precision:       precision,
+		precisionFactor: precisionFactor,
 	}
 }
 
 // Add returns a Float of f + x
 func (f Float) Add(x Float) Float {
-	max := getMaxPrecision(f.precision, x.precision)
+	maxP, maxFact := getMaxPrecision(f, x)
 	sum := f.Float64() + x.Float64()
-	return ToFloat(sum, max)
+	return toFloat(sum, maxP, maxFact)
 }
 
 // Sub returns a Float of f - x
 func (f Float) Sub(x Float) Float {
-	max := getMaxPrecision(f.precision, x.precision)
+	maxP, maxFact := getMaxPrecision(f, x)
 	sub := f.Float64() - x.Float64()
-	return ToFloat(sub, max)
+	return toFloat(sub, maxP, maxFact)
 }
 
 // Multiply returns a Float of f * x
 func (f Float) Multiply(x Float) Float {
-	max := getMaxPrecision(f.precision, x.precision)
+	maxP, maxFact := getMaxPrecision(f, x)
 	mul := f.Float64() * x.Float64()
-	return ToFloat(mul, max)
+	return toFloat(mul, maxP, maxFact)
 }
 
 // Divide returns a Float of f / x
 //
 // Special cases are :
-//  x.Float64 = 0 returns Float value 0
+//
+//	x.Float64 = 0 returns Float value 0
 func (f Float) Divide(x Float) Float {
 	if x.Float64() == 0 {
-		return ToFloat(0, 0)
+		return Float{
+			integer:         0,
+			decimal:         0,
+			precision:       f.precision,
+			precisionFactor: f.precisionFactor,
+		}
 	}
-	max := getMaxPrecision(f.precision, x.precision)
+	maxP, maxFact := getMaxPrecision(f, x)
 	dev := f.Float64() / x.Float64()
-	return ToFloat(dev, max)
+	return toFloat(dev, maxP, maxFact)
 }
 
 // Float64 returns a float64 value of f
 func (f Float) Float64() float64 {
-	floatingLength := int64(math.Trunc(math.Pow(10, float64(f.precision))))
-	return (float64(f.integer*floatingLength) + float64(f.decimal)) / float64(floatingLength)
+	return (float64(f.integer*f.precisionFactor) + float64(f.decimal)) / float64(f.precisionFactor)
 }
 
 func (f Float) String() string {
 	return strconv.FormatFloat(f.Float64(), 'f', f.precision, 64)
 }
 
-func getMaxPrecision(p1, p2 int) (max int) {
-	max = p1
-	if p1 < p2 {
-		max = p2
+func getMaxPrecision(p1, p2 Float) (max int, maxFactor int64) {
+	if p1.precision < p2.precision {
+		return p2.precision, p2.precisionFactor
 	}
-	return
+
+	return p1.precision, p1.precisionFactor
 }

--- a/gofloat_example_test.go
+++ b/gofloat_example_test.go
@@ -2,8 +2,9 @@ package gofloat_test
 
 import (
 	"fmt"
-	"github.com/senpathi/gofloat"
 	"math"
+
+	"github.com/senpathi/gofloat"
 )
 
 func ExampleToFloat() {

--- a/gofloat_test.go
+++ b/gofloat_test.go
@@ -148,11 +148,14 @@ func setupTestTable(operator string) []TestInput {
 			precision2: rand.Intn(9),
 		}
 
-		length1 := math.Trunc(math.Pow(10, float64(inputs[i].precision1)))
-		max := getMaxPrecision(inputs[i].precision1, inputs[i].precision2)
-		lengthMax := math.Trunc(math.Pow(10, float64(max)))
-		rounded1 := ToFloat(inputs[i].input1, inputs[i].precision1).Float64()
-		rounded2 := ToFloat(inputs[i].input2, inputs[i].precision2).Float64()
+		length1 := math.Trunc(math.Pow10(inputs[i].precision1))
+
+		f1 := ToFloat(inputs[i].input1, inputs[i].precision1)
+		rounded1 := f1.Float64()
+		f2 := ToFloat(inputs[i].input2, inputs[i].precision2)
+		rounded2 := f2.Float64()
+		_, maxFact := getMaxPrecision(f1, f2)
+		lengthMax := float64(maxFact)
 
 		switch operator {
 		case `NONE`:


### PR DESCRIPTION
After testing the performance of the benchmarks with the go tool pprof, there was a huge impact from the math package, and mostly `math.Pow()`

So I have changed `math.Pow()` to `math.Pow10` which is a better performer for calculating 10th powers and also stores the calculated power value to avoid later calculations.

Here are the benchmark results before and after
### Before
```
BenchmarkFloat/Bench_ToFloat-10                 92825976                12.73 ns/op
BenchmarkFloat/Bench_Float_Add-10               19134381                62.89 ns/op
BenchmarkFloat/Bench_Float_Sub-10               19082767                62.88 ns/op
BenchmarkFloat/Bench_Float_Multiply-10          19102563                62.86 ns/op
BenchmarkFloat/Bench_Float_Divide-10            15634525                76.69 ns/op
```
### After
```
BenchmarkFloat/Bench_ToFloat-10                 489519688                2.285 ns/op
BenchmarkFloat/Bench_Float_Add-10               134394903                8.932 ns/op
BenchmarkFloat/Bench_Float_Sub-10               134450560                8.930 ns/op
BenchmarkFloat/Bench_Float_Multiply-10          133463366                9.000 ns/op
BenchmarkFloat/Bench_Float_Divide-10            126986404                9.446 ns/op
```